### PR TITLE
Update validation mixin path in config.js

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Novaposhta integration for Magento 2",
     "type": "magento2-module",
     "license": "MIT",
-    "version": "2.4.9.0",
+    "version": "2.4.9.1",
     "authors": [
         {
             "email": "faqreg@gmail.com",

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -4,7 +4,7 @@ var config = {
             'mage/menu': {
                 'Perspective_NovaposhtaShipping/js/lib/mage/menu-mixin': true
             },
-            'mage/validation': {
+            'mage/backend/validation': {
                 'Perspective_NovaposhtaShipping/js/mixin/city-validation-mixin': true
             }
         }
@@ -21,7 +21,7 @@ var config = {
                 'Perspective_NovaposhtaShipping/js/order/address/change/address',
             postbox:
                 'Perspective_NovaposhtaShipping/js/lib/knockout-postbox-min',
-            validation: "mage/validation/validation"
+            validation: "mage/backend/validation"
         }
     }
 };


### PR DESCRIPTION
Changed 'mage/validation' to 'mage/backend/validation' to ensure correct module resolution and improve compatibility.